### PR TITLE
chore: upgrade openapi springdoc to 2.8.14

### DIFF
--- a/core-banking-services/build.gradle
+++ b/core-banking-services/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'


### PR DESCRIPTION
This fixes the issue that swagger-ui wouldn't work with the latest springboot version.